### PR TITLE
性能行为优化

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-activation",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "<KeepAlive /> for React like <keep-alive /> in vue",
   "main": "index.js",
   "scripts": {

--- a/src/core/KeepAlive.js
+++ b/src/core/KeepAlive.js
@@ -45,9 +45,9 @@ class KeepAlive extends Component {
   }, 100)
   releaseUpdateTimes = debounce(() => {
     this.updateTimes = 0
-  }, 32)
+  }, 16)
   needForceStopUpdate = () => {
-    const needForceStopUpdate = this.updateTimes > 16
+    const needForceStopUpdate = this.updateTimes > 64
 
     if (needForceStopUpdate) {
       this.errorTips()

--- a/src/core/Keeper.js
+++ b/src/core/Keeper.js
@@ -9,6 +9,16 @@ import { LIFECYCLE_ACTIVATE, LIFECYCLE_UNACTIVATE } from './lifecycles'
 export default class Keeper extends Component {
   listeners = new Map()
   wrapper = null
+
+  constructor(props, ...rest) {
+    super(props, ...rest)
+
+    this.state = {
+      children: props.children,
+      bridgeProps: props.bridgeProps
+    }
+  }
+
   componentDidMount() {
     const { store, id } = this.props
     const listeners = this.listeners
@@ -32,7 +42,7 @@ export default class Keeper extends Component {
   }
 
   componentWillUnmount() {
-    const { store, id } = this.props
+    const { store, keepers, id } = this.props
     // 卸载前尝试归位 DOM 节点
     try {
       const cache = store.get(id)
@@ -43,6 +53,7 @@ export default class Keeper extends Component {
       // console.error(error) // do nothing
     }
     store.delete(id)
+    keepers.delete(id)
   }
 
   [LIFECYCLE_ACTIVATE]() {
@@ -105,7 +116,8 @@ export default class Keeper extends Component {
   }
 
   render() {
-    const { id, children, bridgeProps, ...props } = this.props
+    const { id, ...props } = this.props
+    const { children, bridgeProps } = this.state
 
     return (
       <div


### PR DESCRIPTION
- 尝试解除 KeepAlive children update 时亦触发 AliveScope 更新的性能损耗问题，只更新其对应 Keeper
- KeepAlive 瞬时更新锁检测条件放宽，减轻对正常更新行为的误判情况

一定程度上，可能修复 #13 场景的性能问题