### PR TITLE
🌟 使 `CachingNode` 节点存储的字段支持读取而不报错

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ export interface KeepAliveProps {
 }
 
 export declare class KeepAlive extends React.Component<KeepAliveProps> {}
-export default KeepAlive 
+export default KeepAlive
 
 export declare class AliveScope extends React.Component<{
   children: ReactNode | ReactNodeArray
@@ -33,6 +33,7 @@ export interface CachingNode {
   updateTime: number
   name?: string
   id: string
+  [key: string]: any
 }
 export interface AliveController {
   drop: (name: string | RegExp) => Promise<boolean>


### PR DESCRIPTION
比如在某个场景，可能在 `KeepAlive` 参数上加入额外的自定义标识，比如路由中的 `query`，

则在 `getCachingNodes` 返回值中允许读取自定义标识。