### PR TITLE
fix: core-js 调整为devDependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules
 lib
+
+# editor
+.idea
+.vscode

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "react": ">=16"
   },
   "dependencies": {
-    "core-js": "^3.6.5",
     "create-react-context": "^0.3.0",
     "hoist-non-react-statics": "^3.3.0",
     "jsx-ast-utils": "^2.2.1",
@@ -49,6 +48,7 @@
     "@babel/plugin-proposal-class-properties": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-react": "^7.0.0",
+    "core-js": "^3.7.0",
     "np": "^6.2.5",
     "rollup": "^1.11.3",
     "rollup-plugin-babel": "^4.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,6 +1209,11 @@ core-js@^3.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
   integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
+core-js@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.npm.taobao.org/core-js/download/core-js-3.7.0.tgz?cache=0&sync_timestamp=1604675690423&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcore-js%2Fdownload%2Fcore-js-3.7.0.tgz#b0a761a02488577afbf97179e4681bf49568520f"
+  integrity sha1-sKdhoCSIV3r7+XF55Ggb9JVoUg8=
+
 cosmiconfig@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"


### PR DESCRIPTION
core-js 调整为devDependencies,  
优化 react-activation 体积, analyzer gzip 从 20.58 => 7.04,  
避免webpack打包多个版本的core-js