### PR TITLE
feat: 增加 saveScrollPositionIgnoreNodeIds 属性以支持忽略特定元素的滚动位置缓存

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,12 @@ If your components share screen scroll container, `document.body` or `document.d
 <KeepAlive saveScrollPosition="screen" />
 ```
 
+If you need to ignore scroll position caching for specific elements, you can use the `saveScrollPositionIgnoreNodeIds` prop to specify a list of element IDs to ignore
+
+```javascript
+<KeepAlive saveScrollPositionIgnoreNodeIds={['header', 'sidebar']} />
+```
+
 ---
 
 ## Principle

--- a/README_CN.md
+++ b/README_CN.md
@@ -373,6 +373,12 @@ class App extends Component {
 <KeepAlive saveScrollPosition="screen" />
 ```
 
+如果你需要忽略某些特定元素的滚动位置缓存，可以通过 `saveScrollPositionIgnoreNodeIds` 属性指定要忽略的元素 ID 列表
+
+```javascript
+<KeepAlive saveScrollPositionIgnoreNodeIds={['header', 'sidebar']} />
+```
+
 ---
 
 ## 原理概述

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ export interface KeepAliveProps {
   autoFreeze?: boolean
   wrapperProps?: DivProps
   contentProps?: DivProps
+  saveScrollPositionIgnoreNodeIds?: string[]
   [key: string]: any
 }
 

--- a/src/core/KeepAlive.js
+++ b/src/core/KeepAlive.js
@@ -106,7 +106,7 @@ class KeepAlive extends Component {
 
   // DOM 操作将实际内容移出占位元素
   eject = (willUnactivate = true) => {
-    const { id, _helpers } = this.props
+    const { id, _helpers, saveScrollPositionIgnoreNodeIds } = this.props
     const cache = _helpers.getCache(id)
     const nodesNeedToSaveScrollPosition = flatten(
       flatten([this.props.saveScrollPosition]).map((flag) => {
@@ -127,7 +127,10 @@ class KeepAlive extends Component {
       if (willUnactivate && nodesNeedToSaveScrollPosition.length > 0) {
         // 保存该节点下各可滚动元素的滚动位置
         cache.revertScrollPos = saveScrollPosition(
-          nodesNeedToSaveScrollPosition
+          nodesNeedToSaveScrollPosition,
+          {
+            ignoreNodeIds: saveScrollPositionIgnoreNodeIds,
+          }
         )
       }
 

--- a/src/helpers/saveScrollPosition.js
+++ b/src/helpers/saveScrollPosition.js
@@ -28,8 +28,12 @@ function getScrollableNodes(from) {
   )
 }
 
-export default function saveScrollPosition(from) {
-  const nodes = [...new Set([...flatten(from.map(getScrollableNodes))])]
+export default function saveScrollPosition(from, options = {}) {
+  const { ignoreNodeIds = [] } = options
+
+  const nodes = [...new Set([...flatten(from.map(getScrollableNodes))])].filter(
+    (node) => !ignoreNodeIds.includes(node.id)
+  )
 
   const saver = nodes.map((node) => [
     node,


### PR DESCRIPTION
## 背景与需求

在使用 `react-activation` 进行组件状态保持时，`saveScrollPosition` 功能会自动保存和恢复页面中所有可滚动元素的滚动位置。哪怕滚动元素在KeepAlive包裹之外，但在某些业务场景中，我们需要对特定的元素进行例外处理，比如：

1. **固定导航栏或侧边栏**：这些元素的滚动位置不应该被保存，因为它们在不同页面间应该保持初始状态
2. **动态内容区域**：某些滚动容器的内容可能会动态变化，保存滚动位置可能导致用户体验问题

### 解决方案

新增 `saveScrollPositionIgnoreNodeIds` 属性，允许指定要忽略滚动位置缓存的元素ID列表。

### 主要修改内容

#### 1. 类型定义更新 (`index.d.ts`)
```typescript
export interface KeepAliveProps {
  // ... 其他属性
  saveScrollPositionIgnoreNodeIds?: string[]
}
```

#### 2. 核心逻辑修改 (`src/core/KeepAlive.js`)
- 在 `eject` 方法中接收新的 `saveScrollPositionIgnoreNodeIds` 属性
- 将该参数传递给 `saveScrollPosition` 函数

#### 3. 滚动位置保存函数增强 (`src/helpers/saveScrollPosition.js`)
- 新增 `options` 参数支持，包含 `ignoreNodeIds` 配置
- 在获取可滚动节点时过滤掉指定ID的元素

#### 4. 文档更新 (`README.md` & `README_CN.md`)
- 添加新参数的使用说明和示例代码

### 使用示例

```javascript
// 忽略元素id为'header', 'sidebar'的置顶导航栏和侧边栏的滚动位置缓存
<KeepAlive saveScrollPositionIgnoreNodeIds={['header', 'sidebar']}>
  <YourComponent />
</KeepAlive>
```